### PR TITLE
Implementa exibição de orientações

### DIFF
--- a/novo projeto junho/app/(atleta)/index.tsx
+++ b/novo projeto junho/app/(atleta)/index.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getSportConfig, getSportStatistics, getSportPositions } from '../../utils/sportsConfig';
+import OrientacaoItem, { Orientacao } from '../../components/OrientacaoItem';
 
 interface AtletaStats {
   [key: string]: any;
@@ -26,14 +27,6 @@ interface AtletaStats {
   cartoes: number;
 }
 
-interface Orientacao {
-  id: string;
-  tipo: string;
-  titulo: string;
-  descricao: string;
-  data: string;
-  lida: boolean;
-}
 
 export default function AtletaHome() {
   const { user } = useAuth();
@@ -183,6 +176,10 @@ export default function AtletaHome() {
   };
 
   const orientacaoNaoLidas = orientacoes.filter(o => !o.lida);
+  const orientacoesOrdenadas = [...orientacoes].sort(
+    (a, b) => new Date(b.data).getTime() - new Date(a.data).getTime()
+  );
+  const orientacaoDestaque = orientacoesOrdenadas[0];
 
   return (
     <SafeAreaView style={styles.container}>
@@ -264,32 +261,13 @@ export default function AtletaHome() {
         {/* Orientações do Professor */}
         <View style={styles.orientacoesSection}>
           <Text style={styles.sectionTitle}>Orientações do Professor</Text>
-          {orientacoes.length > 0 ? (
+          {orientacaoDestaque ? (
             <View style={styles.orientacoesList}>
-              {orientacoes.slice(0, 2).map((orientacao, index) => (
-                <View key={index} style={styles.orientacaoCard}>
-                  <View style={styles.orientacaoHeader}>
-                    <Ionicons 
-                      name={orientacao.tipo === 'treino' ? 'basketball' : 
-                            orientacao.tipo === 'alimentacao' ? 'nutrition' : 
-                            orientacao.tipo === 'recuperacao' ? 'fitness' : 'chatbubble'} 
-                      size={24} 
-                      color="#4CAF50" 
-                    />
-                    <Text style={styles.orientacaoTipo}>
-                      {orientacao.tipo === 'treino' ? 'Treino' :
-                       orientacao.tipo === 'alimentacao' ? 'Alimentação' :
-                       orientacao.tipo === 'recuperacao' ? 'Recuperação' : 'Geral'}
-                    </Text>
-                  </View>
-                  <Text style={styles.orientacaoTexto} numberOfLines={2}>
-                    {orientacao.descricao}
-                  </Text>
-                  <Text style={styles.orientacaoData}>
-                    {new Date(orientacao.data).toLocaleDateString('pt-BR')}
-                  </Text>
-                </View>
-              ))}
+              <OrientacaoItem
+                orientacao={orientacaoDestaque}
+                highlight
+                onMarkAsRead={marcarOrientacaoLida}
+              />
             </View>
           ) : (
             <View style={styles.noOrientacoesCard}>
@@ -500,43 +478,6 @@ const styles = StyleSheet.create({
   },
   orientacoesList: {
     marginBottom: 15,
-  },
-  orientacaoCard: {
-    backgroundColor: '#f8f9fa',
-    borderRadius: 12,
-    padding: 15,
-    marginBottom: 10,
-  },
-  orientacaoHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8,
-  },
-  orientacaoIcon: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: 10,
-  },
-  orientacaoInfo: {
-    flex: 1,
-  },
-  orientacaoTitulo: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: '#333',
-  },
-  orientacaoData: {
-    fontSize: 12,
-    color: '#666',
-    marginTop: 2,
-  },
-  orientacaoDescricao: {
-    fontSize: 14,
-    color: '#666',
-    lineHeight: 20,
   },
   noOrientacoesCard: {
     backgroundColor: '#fff',

--- a/novo projeto junho/app/(atleta)/orientacoes.tsx
+++ b/novo projeto junho/app/(atleta)/orientacoes.tsx
@@ -10,16 +10,9 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../contexts/AuthContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { getSportConfig, getSportGuidance } from '../../utils/sportsConfig';
 
-interface Orientacao {
-  id: string;
-  tipo: string;
-  titulo: string;
-  descricao: string;
-  data: string;
-  status: 'pendente' | 'concluida';
-}
+import OrientacaoItem, { Orientacao } from '../../components/OrientacaoItem';
+
 
 export default function OrientacoesAtleta() {
   const { user } = useAuth();
@@ -33,23 +26,14 @@ export default function OrientacoesAtleta() {
   async function loadOrientacoes() {
     try {
       setLoading(true);
-      const storedGuidance = await AsyncStorage.getItem(`@GestaoTimes:guidance_${user?.id}`);
-      
-      if (storedGuidance) {
-        const guidance = JSON.parse(storedGuidance);
-        
-        // Verificar se as orientações são válidas para o esporte
-        const sportConfig = getSportConfig(user?.sport || 'futebol');
-        const validGuidanceTypes = sportConfig?.guidanceTypes || [];
-        
-        const validGuidance = guidance.filter((g: Orientacao) => 
-          validGuidanceTypes.includes(g.tipo)
-        );
-        
-        setOrientacoes(validGuidance);
-      } else {
-        setOrientacoes([]);
-      }
+      const storedData = await AsyncStorage.getItem(`@GestaoTimes:orientacoes_${user?.id}`);
+
+      const list: Orientacao[] = storedData ? JSON.parse(storedData) : [];
+      const ordered = list.sort(
+        (a, b) => new Date(b.data).getTime() - new Date(a.data).getTime()
+      );
+
+      setOrientacoes(ordered);
     } catch (error) {
       console.log('Erro ao carregar orientações:', error);
       setOrientacoes([]);
@@ -58,37 +42,17 @@ export default function OrientacoesAtleta() {
     }
   }
 
-  const getGuidanceIcon = (tipo: string) => {
-    switch (tipo) {
-      case 'treino':
-        return 'fitness';
-      case 'tatica':
-        return 'grid';
-      case 'fisico':
-        return 'barbell';
-      case 'nutricao':
-        return 'nutrition';
-      case 'recuperacao':
-        return 'medkit';
-      default:
-        return 'help-circle';
-    }
-  };
+  const marcarOrientacaoLida = async (id: string) => {
+    const novas = orientacoes.map(o => (o.id === id ? { ...o, lida: true } : o));
+    setOrientacoes(novas);
 
-  const getGuidanceColor = (tipo: string) => {
-    switch (tipo) {
-      case 'treino':
-        return '#4CAF50';
-      case 'tatica':
-        return '#2196F3';
-      case 'fisico':
-        return '#FF9800';
-      case 'nutricao':
-        return '#E91E63';
-      case 'recuperacao':
-        return '#9C27B0';
-      default:
-        return '#757575';
+    try {
+      await AsyncStorage.setItem(
+        `@GestaoTimes:orientacoes_${user?.id}`,
+        JSON.stringify(novas)
+      );
+    } catch (error) {
+      console.log('Erro ao atualizar orientação:', error);
     }
   };
 
@@ -115,41 +79,11 @@ export default function OrientacoesAtleta() {
           </View>
         ) : (
           orientacoes.map((orientacao) => (
-            <View key={orientacao.id} style={styles.orientacaoCard}>
-              <View style={styles.orientacaoHeader}>
-                <View style={styles.orientacaoIconContainer}>
-                  <Ionicons
-                    name={getGuidanceIcon(orientacao.tipo)}
-                    size={24}
-                    color={getGuidanceColor(orientacao.tipo)}
-                  />
-                </View>
-                <View style={styles.orientacaoInfo}>
-                  <Text style={styles.orientacaoTitulo}>{orientacao.titulo}</Text>
-                  <Text style={styles.orientacaoData}>{orientacao.data}</Text>
-                </View>
-                <View
-                  style={[
-                    styles.statusBadge,
-                    {
-                      backgroundColor:
-                        orientacao.status === 'concluida'
-                          ? '#4CAF50'
-                          : '#FFC107',
-                    },
-                  ]}
-                >
-                  <Text style={styles.statusText}>
-                    {orientacao.status === 'concluida'
-                      ? 'Concluída'
-                      : 'Pendente'}
-                  </Text>
-                </View>
-              </View>
-              <Text style={styles.orientacaoDescricao}>
-                {orientacao.descricao}
-              </Text>
-            </View>
+            <OrientacaoItem
+              key={orientacao.id}
+              orientacao={orientacao}
+              onMarkAsRead={marcarOrientacaoLida}
+            />
           ))
         )}
       </ScrollView>
@@ -199,58 +133,5 @@ const styles = StyleSheet.create({
     color: '#757575',
     textAlign: 'center',
     marginTop: 16,
-  },
-  orientacaoCard: {
-    backgroundColor: '#fff',
-    margin: 10,
-    padding: 15,
-    borderRadius: 10,
-    elevation: 2,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-  },
-  orientacaoHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 10,
-  },
-  orientacaoIconContainer: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: '#f5f5f5',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: 10,
-  },
-  orientacaoInfo: {
-    flex: 1,
-  },
-  orientacaoTitulo: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: '#333',
-  },
-  orientacaoData: {
-    fontSize: 12,
-    color: '#666',
-    marginTop: 2,
-  },
-  statusBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 12,
-  },
-  statusText: {
-    color: '#fff',
-    fontSize: 12,
-    fontWeight: '500',
-  },
-  orientacaoDescricao: {
-    fontSize: 14,
-    color: '#666',
-    lineHeight: 20,
   },
 }); 

--- a/novo projeto junho/components/OrientacaoItem.tsx
+++ b/novo projeto junho/components/OrientacaoItem.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+export interface Orientacao {
+  id: string;
+  tipo: string;
+  titulo: string;
+  descricao: string;
+  data: string;
+  lida: boolean;
+}
+
+interface OrientacaoItemProps {
+  orientacao: Orientacao;
+  highlight?: boolean;
+  onMarkAsRead?: (id: string) => void;
+}
+
+function getIconName(tipo: string) {
+  switch (tipo) {
+    case 'treino':
+      return 'basketball';
+    case 'alimentacao':
+      return 'nutrition';
+    case 'recuperacao':
+      return 'fitness';
+    default:
+      return 'chatbubble';
+  }
+}
+
+export default function OrientacaoItem({ orientacao, highlight, onMarkAsRead }: OrientacaoItemProps) {
+  const icon = getIconName(orientacao.tipo);
+  return (
+    <View style={[styles.container, highlight && styles.highlight]}>
+      <View style={styles.row}>
+        <Ionicons name={icon as any} size={24} color="#4CAF50" style={styles.icon} />
+        <View style={{ flex: 1 }}>
+          <Text style={styles.titulo}>{orientacao.titulo}</Text>
+          <Text style={styles.data}>{new Date(orientacao.data).toLocaleDateString('pt-BR')}</Text>
+        </View>
+        {!orientacao.lida && onMarkAsRead && (
+          <TouchableOpacity onPress={() => onMarkAsRead(orientacao.id)} style={styles.markButton}>
+            <Ionicons name="checkmark" size={20} color="#fff" />
+          </TouchableOpacity>
+        )}
+      </View>
+      <Text style={styles.descricao} numberOfLines={highlight ? 3 : 2}>
+        {orientacao.descricao}
+      </Text>
+      {orientacao.lida && <Text style={styles.lida}>Lida</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#f8f9fa',
+    borderRadius: 12,
+    padding: 15,
+    marginBottom: 10,
+  },
+  highlight: {
+    borderWidth: 1,
+    borderColor: '#4CAF50',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  icon: {
+    marginRight: 8,
+  },
+  titulo: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  data: {
+    fontSize: 12,
+    color: '#666',
+  },
+  descricao: {
+    fontSize: 14,
+    color: '#666',
+  },
+  markButton: {
+    backgroundColor: '#4CAF50',
+    padding: 6,
+    borderRadius: 12,
+  },
+  lida: {
+    marginTop: 4,
+    fontSize: 12,
+    color: '#4CAF50',
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Summary
- cria componente `OrientacaoItem`
- mostra orientação mais recente em destaque na home do atleta
- lista histórico de orientações em ordem cronológica com marcação de leitura

## Testing
- `npm run type-check` *(fails: Cannot find module ...)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4316e83c8325a634b64446bc090f