### PR TITLE
Add charts and share option to athlete stats

### DIFF
--- a/novo projeto junho/app/(atleta)/estatisticas.tsx
+++ b/novo projeto junho/app/(atleta)/estatisticas.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -6,8 +6,12 @@ import {
   ScrollView,
   SafeAreaView,
   TouchableOpacity,
+  Dimensions,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import ViewShot, { captureRef } from 'react-native-view-shot';
+import * as Sharing from 'expo-sharing';
+import { BarChart, PieChart } from 'react-native-chart-kit';
 import { useAuth } from '../../contexts/AuthContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getSportConfig, getSportStatistics, getSportPositions } from '../../utils/sportsConfig';
@@ -38,10 +42,52 @@ export default function EstatisticasAtleta() {
     ultimosJogos: [],
   });
   const [periodoSelecionado, setPeriodoSelecionado] = useState('mes');
+  const viewShotRef = useRef<ViewShot>(null);
+  const screenWidth = Dimensions.get('window').width - 40;
+  const chartColors = ['#4CAF50', '#2196F3', '#FF9800', '#9C27B0', '#F44336'];
 
   useEffect(() => {
     loadEstatisticas();
   }, []);
+
+  const periodTotals = calcularEstatisticasPeriodo(periodoSelecionado);
+
+  const calcularEstatisticasPeriodo = (periodo: string) => {
+    const agora = new Date();
+    const jogosFiltrados = stats.ultimosJogos.filter(jogo => {
+      const data = new Date(jogo.data);
+      if (periodo === 'mes') {
+        return data.getMonth() === agora.getMonth() && data.getFullYear() === agora.getFullYear();
+      }
+      if (periodo === 'temporada') {
+        return data.getFullYear() === agora.getFullYear();
+      }
+      return true; // carreira
+    });
+
+    return jogosFiltrados.reduce(
+      (totais, jogo) => {
+        totais.gols += jogo.stats.gols || 0;
+        totais.assistencias += jogo.stats.assistencias || 0;
+        totais.bloqueios += jogo.stats.bloqueios || 0;
+        const pos = (jogo as any).posicao || stats.posicao;
+        totais.desempenhoPorPosicao[pos] = (totais.desempenhoPorPosicao[pos] || 0) + 1;
+        return totais;
+      },
+      { gols: 0, assistencias: 0, bloqueios: 0, desempenhoPorPosicao: {} as Record<string, number> }
+    );
+  };
+
+  const compartilharDesempenho = async () => {
+    try {
+      const uri = await captureRef(viewShotRef);
+      if (uri) {
+        await Sharing.shareAsync(uri);
+      }
+    } catch (error) {
+      console.log('Erro ao compartilhar desempenho:', error);
+    }
+  };
 
   async function loadEstatisticas() {
     try {
@@ -125,7 +171,8 @@ export default function EstatisticasAtleta() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <ScrollView showsVerticalScrollIndicator={false}>
+      <ViewShot ref={viewShotRef} style={{ flex: 1 }}>
+        <ScrollView showsVerticalScrollIndicator={false}>
         {/* Seletor de Período */}
         <View style={styles.periodSelector}>
           {periodos.map((periodo) => (
@@ -212,6 +259,49 @@ export default function EstatisticasAtleta() {
               <Ionicons name="trending-up" size={32} color="#ccc" />
               <Text style={styles.noDataText}>Aguardando registro de jogos</Text>
             </View>
+          )}
+        </View>
+
+        {/* Gráficos de Estatísticas */}
+        <View style={styles.chartSection}>
+          <Text style={styles.sectionTitle}>Resumo {periodos.find(p => p.value === periodoSelecionado)?.label}</Text>
+          <BarChart
+            data={{
+              labels: ['Gols', 'Assist.', 'Bloq.'],
+              datasets: [{ data: [periodTotals.gols, periodTotals.assistencias, periodTotals.bloqueios] }]
+            }}
+            width={screenWidth}
+            height={220}
+            fromZero
+            showValuesOnTopOfBars
+            chartConfig={{
+              backgroundColor: '#fff',
+              backgroundGradientFrom: '#fff',
+              backgroundGradientTo: '#fff',
+              decimalPlaces: 0,
+              color: (opacity = 1) => `rgba(76, 175, 80, ${opacity})`,
+              labelColor: (opacity = 1) => `rgba(0,0,0,${opacity})`,
+              propsForBackgroundLines: { stroke: '#e0e0e0' },
+            }}
+            style={{ borderRadius: 16 }}
+          />
+
+          {Object.keys(periodTotals.desempenhoPorPosicao).length > 0 && (
+            <PieChart
+              data={Object.entries(periodTotals.desempenhoPorPosicao).map(([pos, count], index) => ({
+                name: pos,
+                population: count,
+                color: chartColors[index % chartColors.length],
+                legendFontColor: '#333',
+                legendFontSize: 12,
+              }))}
+              width={screenWidth}
+              height={220}
+              accessor="population"
+              paddingLeft="15"
+              chartConfig={{ color: () => '#000' }}
+              style={{ marginTop: 20 }}
+            />
           )}
         </View>
 
@@ -309,7 +399,15 @@ export default function EstatisticasAtleta() {
             </View>
           </View>
         </View>
+
+        <View style={styles.shareContainer}>
+          <TouchableOpacity style={styles.shareButton} onPress={compartilharDesempenho}>
+            <Ionicons name="share-social" size={20} color="#fff" />
+            <Text style={styles.shareButtonText}>Compartilhar desempenho</Text>
+          </TouchableOpacity>
+        </View>
       </ScrollView>
+      </ViewShot>
     </SafeAreaView>
   );
 }
@@ -543,6 +641,30 @@ const styles = StyleSheet.create({
     height: '100%',
     backgroundColor: '#4CAF50',
     borderRadius: 4,
+  },
+  chartSection: {
+    marginHorizontal: 20,
+    marginBottom: 20,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+  },
+  shareContainer: {
+    alignItems: 'center',
+    marginBottom: 40,
+  },
+  shareButton: {
+    flexDirection: 'row',
+    backgroundColor: '#4CAF50',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    alignItems: 'center',
+    gap: 8,
+  },
+  shareButtonText: {
+    color: '#fff',
+    fontWeight: 'bold',
   },
   noDataContainer: {
     flex: 1,

--- a/novo projeto junho/package-lock.json
+++ b/novo projeto junho/package-lock.json
@@ -22,6 +22,7 @@
         "expo-linear-gradient": "~14.1.0",
         "expo-linking": "~7.1.5",
         "expo-router": "~5.0.0",
+        "expo-sharing": "^13.1.5",
         "expo-splash-screen": "~0.30.0",
         "expo-status-bar": "~2.2.0",
         "expo-symbols": "~0.4.0",
@@ -37,7 +38,8 @@
         "react-native-safe-area-context": "^5.4.0",
         "react-native-screens": "~4.11.0",
         "react-native-svg": "15.11.2",
-        "react-native-vector-icons": "^10.0.3"
+        "react-native-vector-icons": "^10.0.3",
+        "react-native-view-shot": "^4.0.3"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -4494,6 +4496,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5219,6 +5230,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -6580,6 +6600,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/expo-sharing": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-13.1.5.tgz",
+      "integrity": "sha512-X/5sAEiWXL2kdoGE3NO5KmbfcmaCWuWVZXHu8OQef7Yig4ZgHFkGD11HKJ5KqDrDg+SRZe4ISd6MxE7vGUgm4w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-splash-screen": {
       "version": "0.30.8",
       "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.30.8.tgz",
@@ -7328,6 +7357,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -11202,6 +11244,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-native-view-shot": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
+      "integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "html2canvas": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -12710,6 +12765,15 @@
         "node": "*"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13105,6 +13169,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/novo projeto junho/package.json
+++ b/novo projeto junho/package.json
@@ -26,6 +26,7 @@
     "expo-linear-gradient": "~14.1.0",
     "expo-linking": "~7.1.5",
     "expo-router": "~5.0.0",
+    "expo-sharing": "^13.1.5",
     "expo-splash-screen": "~0.30.0",
     "expo-status-bar": "~2.2.0",
     "expo-symbols": "~0.4.0",
@@ -41,7 +42,8 @@
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "~4.11.0",
     "react-native-svg": "15.11.2",
-    "react-native-vector-icons": "^10.0.3"
+    "react-native-vector-icons": "^10.0.3",
+    "react-native-view-shot": "^4.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- add react-native-view-shot and expo-sharing
- extend EstatisticasAtleta with period charts and share button

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: SyntaxError in eslint config)*
- `npm run type-check` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a43459bac8325a59c4f685ca5e9b4