### PR TITLE
Implement push notifications with badges

### DIFF
--- a/novo projeto junho/.eslintrc.js
+++ b/novo projeto junho/.eslintrc.js
@@ -25,4 +25,7 @@ module.exports = {
   },
   settings: {
     react: {
- 
+      version: 'detect',
+    },
+  },
+};

--- a/novo projeto junho/app/(atleta)/_layout.tsx
+++ b/novo projeto junho/app/(atleta)/_layout.tsx
@@ -1,10 +1,12 @@
 import { Tabs } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../contexts/AuthContext';
+import { useNotifications } from '../../contexts/NotificationContext';
 import { Redirect } from 'expo-router';
 
 export default function AtletaLayout() {
   const { user } = useAuth();
+  const { badges } = useNotifications();
 
   // Redirecionar se não for atleta
   if (user && user.userType !== 'atleta') {
@@ -59,6 +61,7 @@ export default function AtletaLayout() {
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="stats-chart" size={size} color={color} />
           ),
+          tabBarBadge: badges.stats ? '' : undefined,
           headerTitle: 'Minhas Estatísticas',
         }}
       />
@@ -69,6 +72,7 @@ export default function AtletaLayout() {
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="school" size={size} color={color} />
           ),
+          tabBarBadge: badges.guidance ? '' : undefined,
           headerTitle: 'Orientações do Professor',
         }}
       />
@@ -79,6 +83,7 @@ export default function AtletaLayout() {
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="calendar" size={size} color={color} />
           ),
+          tabBarBadge: badges.events ? '' : undefined,
           headerTitle: 'Minha Agenda',
         }}
       />

--- a/novo projeto junho/app/(atleta)/agenda.tsx
+++ b/novo projeto junho/app/(atleta)/agenda.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../contexts/AuthContext';
+import { useNotifications } from '../../contexts/NotificationContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getSportConfig, getSportEvents } from '../../utils/sportsConfig';
 
@@ -25,11 +26,13 @@ interface Evento {
 
 export default function AgendaAtleta() {
   const { user } = useAuth();
+  const { clearBadge } = useNotifications();
   const [eventos, setEventos] = useState<Evento[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     loadEventos();
+    clearBadge('events');
   }, []);
 
   async function loadEventos() {

--- a/novo projeto junho/app/(atleta)/estatisticas.tsx
+++ b/novo projeto junho/app/(atleta)/estatisticas.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../contexts/AuthContext';
+import { useNotifications } from '../../contexts/NotificationContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getSportConfig, getSportStatistics, getSportPositions } from '../../utils/sportsConfig';
 
@@ -29,6 +30,7 @@ interface EstatisticasDetalhadas {
 
 export default function EstatisticasAtleta() {
   const { user } = useAuth();
+  const { clearBadge } = useNotifications();
   const [stats, setStats] = useState<EstatisticasDetalhadas>({
     minutosJogados: 0,
     aproveitamento: 0,
@@ -41,6 +43,7 @@ export default function EstatisticasAtleta() {
 
   useEffect(() => {
     loadEstatisticas();
+    clearBadge('stats');
   }, []);
 
   async function loadEstatisticas() {

--- a/novo projeto junho/app/(atleta)/orientacoes.tsx
+++ b/novo projeto junho/app/(atleta)/orientacoes.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../contexts/AuthContext';
+import { useNotifications } from '../../contexts/NotificationContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getSportConfig, getSportGuidance } from '../../utils/sportsConfig';
 
@@ -23,11 +24,13 @@ interface Orientacao {
 
 export default function OrientacoesAtleta() {
   const { user } = useAuth();
+  const { clearBadge } = useNotifications();
   const [orientacoes, setOrientacoes] = useState<Orientacao[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     loadOrientacoes();
+    clearBadge('guidance');
   }, []);
 
   async function loadOrientacoes() {

--- a/novo projeto junho/app/_layout.tsx
+++ b/novo projeto junho/app/_layout.tsx
@@ -4,6 +4,7 @@ import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { AuthProvider, useAuth } from '../contexts/AuthContext';
+import { NotificationProvider } from '../contexts/NotificationContext';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
@@ -93,10 +94,12 @@ export default function RootLayout() {
   return (
     <ThemeProvider value={colorScheme.isDark ? DarkTheme : DefaultTheme}>
       <AuthProvider>
-        <AppDataProvider>
-          <RootLayoutNav />
-          <StatusBar style="auto" />
-        </AppDataProvider>
+        <NotificationProvider>
+          <AppDataProvider>
+            <RootLayoutNav />
+            <StatusBar style="auto" />
+          </AppDataProvider>
+        </NotificationProvider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/novo projeto junho/contexts/AppDataContext.tsx
+++ b/novo projeto junho/contexts/AppDataContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { getItem, setItem, StorageKeys } from '../utils/storage';
+import { useNotifications } from './NotificationContext';
 
 interface Team {
   id: string;
@@ -36,13 +37,23 @@ interface Event {
   createdAt: string;
 }
 
+interface Guidance {
+  id: string;
+  tipo: string;
+  titulo: string;
+  descricao: string;
+  data: string;
+}
+
 interface AppDataContextType {
   teams: Team[];
   players: Player[];
   events: Event[];
-  addTeam: (team: Omit<Team, 'id' | 'createdAt'>) => void;
-  addPlayer: (player: Omit<Player, 'id' | 'createdAt'>) => void;
-  addEvent: (event: Omit<Event, 'id' | 'createdAt'>) => void;
+  addTeam: (team: Omit<Team, 'id' | 'createdAt'>) => Promise<void>;
+  addPlayer: (player: Omit<Player, 'id' | 'createdAt'>) => Promise<void>;
+  addEvent: (event: Omit<Event, 'id' | 'createdAt'>) => Promise<void>;
+  addGuidance: (playerId: string, guidance: Omit<Guidance, 'id'>) => Promise<void>;
+  addPlayerStats: (playerId: string, stats: Record<string, number>) => Promise<void>;
   updateTeam: (id: string, team: Partial<Team>) => void;
   updatePlayer: (id: string, player: Partial<Player>) => void;
   deleteTeam: (id: string) => void;
@@ -174,6 +185,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
   const [teams, setTeams] = useState<Team[]>([]);
   const [players, setPlayers] = useState<Player[]>([]);
   const [events, setEvents] = useState<Event[]>([]);
+  const { notifyEvent, notifyStats, notifyGuidance } = useNotifications();
 
   // Carregar dados do storage
   useEffect(() => {
@@ -304,6 +316,30 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
     };
     const newEvents = [...events, newEvent];
     await saveEvents(newEvents);
+    await notifyEvent('Novo evento', `${newEvent.title} em ${newEvent.date}`);
+  };
+
+  const addGuidance = async (
+    playerId: string,
+    guidanceData: Omit<Guidance, 'id'>
+  ) => {
+    const storageKey = `@GestaoTimes:guidance_${playerId}`;
+    const stored = await getItem<Guidance[]>(storageKey);
+    const newGuidance: Guidance = { ...guidanceData, id: Date.now().toString() };
+    const list = stored ? [...stored, newGuidance] : [newGuidance];
+    await setItem(storageKey, list);
+    await notifyGuidance('Nova orientação', newGuidance.titulo);
+  };
+
+  const addPlayerStats = async (
+    playerId: string,
+    stats: Record<string, number>
+  ) => {
+    const storageKey = `@GestaoTimes:player_stats_${playerId}`;
+    const stored = await getItem<Record<string, number>>(storageKey);
+    const updated = { ...(stored || {}), ...stats };
+    await setItem(storageKey, updated);
+    await notifyStats('Estatísticas atualizadas', 'Confira suas novas estatísticas');
   };
 
   const updateTeam = async (id: string, teamData: Partial<Team>) => {
@@ -381,6 +417,8 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
       addTeam,
       addPlayer,
       addEvent,
+      addGuidance,
+      addPlayerStats,
       updateTeam,
       updatePlayer,
       deleteTeam,

--- a/novo projeto junho/contexts/NotificationContext.tsx
+++ b/novo projeto junho/contexts/NotificationContext.tsx
@@ -1,0 +1,91 @@
+import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface NotificationContextType {
+  badges: {
+    events: boolean;
+    stats: boolean;
+    guidance: boolean;
+  };
+  notifyEvent: (title: string, body: string) => Promise<void>;
+  notifyStats: (title: string, body: string) => Promise<void>;
+  notifyGuidance: (title: string, body: string) => Promise<void>;
+  clearBadge: (type: 'events' | 'stats' | 'guidance') => void;
+}
+
+const NotificationContext = createContext<NotificationContextType>({} as NotificationContextType);
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [badges, setBadges] = useState({ events: false, stats: false, guidance: false });
+
+  useEffect(() => {
+    registerForPushNotifications();
+    loadBadges();
+  }, []);
+
+  const loadBadges = async () => {
+    const stored = await AsyncStorage.getItem('@GestaoTimes:badges');
+    if (stored) {
+      setBadges(JSON.parse(stored));
+    }
+  };
+
+  const saveBadges = async (newBadges: typeof badges) => {
+    setBadges(newBadges);
+    await AsyncStorage.setItem('@GestaoTimes:badges', JSON.stringify(newBadges));
+  };
+
+  const schedulePush = async (title: string, body: string) => {
+    await Notifications.scheduleNotificationAsync({
+      content: { title, body },
+      trigger: null,
+    });
+  };
+
+  const notifyEvent = async (title: string, body: string) => {
+    await schedulePush(title, body);
+    await saveBadges({ ...badges, events: true });
+  };
+
+  const notifyStats = async (title: string, body: string) => {
+    await schedulePush(title, body);
+    await saveBadges({ ...badges, stats: true });
+  };
+
+  const notifyGuidance = async (title: string, body: string) => {
+    await schedulePush(title, body);
+    await saveBadges({ ...badges, guidance: true });
+  };
+
+  const clearBadge = (type: 'events' | 'stats' | 'guidance') => {
+    const updated = { ...badges, [type]: false };
+    saveBadges(updated);
+  };
+
+  const registerForPushNotifications = async () => {
+    if (Device.isDevice) {
+      const { status: existingStatus } = await Notifications.getPermissionsAsync();
+      let finalStatus = existingStatus;
+      if (existingStatus !== 'granted') {
+        const { status } = await Notifications.requestPermissionsAsync();
+        finalStatus = status;
+      }
+      if (finalStatus !== 'granted') {
+        return;
+      }
+      await Notifications.getExpoPushTokenAsync();
+    }
+  };
+
+  return (
+    <NotificationContext.Provider value={{ badges, notifyEvent, notifyStats, notifyGuidance, clearBadge }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications() {
+  return useContext(NotificationContext);
+}

--- a/novo projeto junho/package-lock.json
+++ b/novo projeto junho/package-lock.json
@@ -21,6 +21,7 @@
         "expo-image-picker": "~16.1.0",
         "expo-linear-gradient": "~14.1.0",
         "expo-linking": "~7.1.5",
+        "expo-notifications": "^0.31.3",
         "expo-router": "~5.0.0",
         "expo-splash-screen": "~0.30.0",
         "expo-status-bar": "~2.2.0",
@@ -2356,6 +2357,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4246,6 +4253,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4266,7 +4286,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -4488,6 +4507,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4676,7 +4701,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -4695,7 +4719,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4709,7 +4732,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5433,7 +5455,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -5460,7 +5481,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -5637,7 +5657,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5806,7 +5825,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5816,7 +5834,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5854,7 +5871,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6359,6 +6375,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-6.1.4.tgz",
+      "integrity": "sha512-jXVZb3llTQ5j4C/I03GxKjujmhKex9Xo5JDZo/pRjScHSr4NoeMjPKWThyWVlWDM1v5YSEcsRJebVfTvq9SR5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "11.1.5",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.5.tgz",
@@ -6524,6 +6549,26 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.31.3.tgz",
+      "integrity": "sha512-AATxKoav5ZvwcRel2SKYNZc+EvOAKvAjxyBezC8y3J5fMNe/uKIhMzh3FN4fKdOi9ao/UBHkvLiUO2MqVnvBNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.7.4",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~6.1.4",
+        "expo-constants": "~17.1.6"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-router": {
@@ -6862,7 +6907,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -6988,7 +7032,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7022,7 +7065,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7166,7 +7208,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7214,7 +7255,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -7243,7 +7283,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7256,7 +7295,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7535,6 +7573,22 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -7616,7 +7670,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7739,7 +7792,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -7773,6 +7825,22 @@
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -7842,7 +7910,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7925,7 +7992,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -9287,7 +9353,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9957,11 +10022,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9971,7 +10051,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10547,7 +10626,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11626,7 +11704,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11885,7 +11962,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -13098,6 +13174,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -13285,7 +13374,6 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/novo projeto junho/package.json
+++ b/novo projeto junho/package.json
@@ -25,6 +25,7 @@
     "expo-image-picker": "~16.1.0",
     "expo-linear-gradient": "~14.1.0",
     "expo-linking": "~7.1.5",
+    "expo-notifications": "^0.31.3",
     "expo-router": "~5.0.0",
     "expo-splash-screen": "~0.30.0",
     "expo-status-bar": "~2.2.0",


### PR DESCRIPTION
## Summary
- add NotificationContext to manage push notifications and badges
- wrap app with NotificationProvider
- show badges on athlete tabs
- clear badges when opening Agenda, Estatísticas or Orientações screens
- trigger notifications when professor creates events
- expose helper functions to add guidance and stats
- include expo-notifications dependency

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find the config "@react-native")*
- `npm run type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a44f7fad483259217aad81f66775c