### PR TITLE
Implement dark mode

### DIFF
--- a/novo projeto junho/app/(tabs)/configuracoes.tsx
+++ b/novo projeto junho/app/(tabs)/configuracoes.tsx
@@ -15,6 +15,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../contexts/AuthContext';
 import { useRouter } from 'expo-router';
 import { useColorScheme } from '../../hooks/useColorScheme';
+import { Colors } from '../../constants/Colors';
 
 export default function Configuracoes() {
   const { user, signOut, updateProfile } = useAuth();
@@ -473,11 +474,20 @@ export default function Configuracoes() {
   );
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView
+      style={[
+        styles.container,
+        { backgroundColor: isDark ? Colors.dark.background : Colors.light.background },
+      ]}
+    >
       <ScrollView showsVerticalScrollIndicator={false}>
         {/* Header */}
         <View style={styles.header}>
-          <Text style={styles.title}>Configurações</Text>
+          <Text
+            style={[styles.title, { color: isDark ? Colors.dark.text : Colors.light.text }]}
+          >
+            Configurações
+          </Text>
         </View>
 
         {/* User Info */}

--- a/novo projeto junho/app/_layout.tsx
+++ b/novo projeto junho/app/_layout.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet, Platform } from 'react-native';
+import { AppThemeProvider } from '../components/AppThemeProvider';
+import { Colors } from '@/constants/Colors';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
@@ -92,12 +94,14 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme.isDark ? DarkTheme : DefaultTheme}>
-      <AuthProvider>
-        <AppDataProvider>
-          <RootLayoutNav />
-          <StatusBar style="auto" />
-        </AppDataProvider>
-      </AuthProvider>
+      <AppThemeProvider>
+        <AuthProvider>
+          <AppDataProvider>
+            <RootLayoutNav />
+            <StatusBar style="auto" />
+          </AppDataProvider>
+        </AuthProvider>
+      </AppThemeProvider>
     </ThemeProvider>
   );
 }
@@ -107,7 +111,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#fff',
+    backgroundColor: Colors.light.background,
   },
   errorText: {
     fontSize: 18,
@@ -117,7 +121,7 @@ const styles = StyleSheet.create({
   },
   errorDetails: {
     fontSize: 14,
-    color: '#666',
+    color: Colors.light.icon,
     textAlign: 'center',
   },
 }); 

--- a/novo projeto junho/app/cadastro.tsx
+++ b/novo projeto junho/app/cadastro.tsx
@@ -18,6 +18,8 @@ import { AntiAutofillInput } from '../components/AntiAutofillInput';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SPORTS_CONFIG } from '../utils/sportsConfig';
 import DropDownPicker from 'react-native-dropdown-picker';
+import { Colors } from '../constants/Colors';
+import { useColorScheme } from '../hooks/useColorScheme';
 
 interface Professor {
   id: string;
@@ -43,6 +45,7 @@ export default function Cadastro() {
   
   const { signUp } = useAuth();
   const router = useRouter();
+  const { isDark } = useColorScheme();
 
   useEffect(() => {
     loadProfessors();
@@ -194,7 +197,10 @@ export default function Cadastro() {
 
   return (
     <KeyboardAvoidingView
-      style={styles.container}
+      style={[
+        styles.container,
+        { backgroundColor: isDark ? Colors.dark.background : Colors.light.background },
+      ]}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}
     >
@@ -211,8 +217,16 @@ export default function Cadastro() {
             <Ionicons name="arrow-back" size={24} color="#0066FF" />
           </TouchableOpacity>
           <Ionicons name="person-add" size={80} color="#0066FF" />
-          <Text style={styles.title}>Criar Conta</Text>
-          <Text style={styles.subtitle}>Escolha o tipo de perfil e preencha os dados</Text>
+          <Text
+            style={[styles.title, { color: isDark ? Colors.dark.text : Colors.light.text }]}
+          >
+            Criar Conta
+          </Text>
+          <Text
+            style={[styles.subtitle, { color: isDark ? Colors.dark.icon : Colors.light.icon }]}
+          >
+            Escolha o tipo de perfil e preencha os dados
+          </Text>
         </View>
 
         <View style={styles.form}>

--- a/novo projeto junho/app/index.tsx
+++ b/novo projeto junho/app/index.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { Colors } from '../constants/Colors';
+import { useColorScheme } from '../hooks/useColorScheme';
 import { useRouter } from 'expo-router';
 import { useAuth } from '../contexts/AuthContext';
 
 export default function Index() {
   const { user, isLoading } = useAuth();
   const router = useRouter();
+  const { isDark } = useColorScheme();
 
   useEffect(() => {
     if (!isLoading) {
@@ -18,7 +21,12 @@ export default function Index() {
   }, [user, isLoading]);
 
   return (
-    <View style={styles.container}>
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: isDark ? Colors.dark.background : Colors.light.background },
+      ]}
+    >
       <ActivityIndicator size="large" color="#0066FF" />
     </View>
   );

--- a/novo projeto junho/app/login.tsx
+++ b/novo projeto junho/app/login.tsx
@@ -15,6 +15,8 @@ import { useRouter, useFocusEffect } from 'expo-router';
 import { useAuth } from '../contexts/AuthContext';
 import { Ionicons } from '@expo/vector-icons';
 import { AntiAutofillInput } from '../components/AntiAutofillInput';
+import { Colors } from '../constants/Colors';
+import { useColorScheme } from '../hooks/useColorScheme';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -24,6 +26,8 @@ export default function Login() {
   
   const { signIn } = useAuth();
   const router = useRouter();
+  const { isDark } = useColorScheme();
+  const styles = createStyles(isDark);
 
   // Hook para limpar autofill quando a tela for focada
   useFocusEffect(
@@ -144,11 +148,12 @@ export default function Login() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f5f5f5',
-  },
+const createStyles = (isDark: boolean) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: isDark ? Colors.dark.background : Colors.light.background,
+    },
   scrollContainer: {
     flexGrow: 1,
     justifyContent: 'center',
@@ -161,16 +166,16 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: '#333',
+    color: isDark ? Colors.dark.text : Colors.light.text,
     marginTop: 10,
   },
   subtitle: {
     fontSize: 16,
-    color: '#666',
+    color: isDark ? Colors.dark.icon : Colors.light.icon,
     marginTop: 5,
   },
   form: {
-    backgroundColor: '#fff',
+    backgroundColor: isDark ? Colors.dark.background : '#fff',
     borderRadius: 10,
     padding: 20,
     shadowColor: '#000',
@@ -186,11 +191,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     borderWidth: 1,
-    borderColor: '#ddd',
+    borderColor: isDark ? '#444' : '#ddd',
     borderRadius: 8,
     marginBottom: 15,
     paddingHorizontal: 15,
-    backgroundColor: '#f9f9f9',
+    backgroundColor: isDark ? '#333' : '#f9f9f9',
     overflow: 'hidden',
     // Força fundo branco mais agressivamente
     shadowColor: 'transparent',
@@ -206,8 +211,8 @@ const styles = StyleSheet.create({
     flex: 1,
     height: 50,
     fontSize: 16,
-    color: '#333',
-    backgroundColor: '#f9f9f9',
+    color: isDark ? Colors.dark.text : '#333',
+    backgroundColor: isDark ? '#333' : '#f9f9f9',
     borderWidth: 0,
     outlineWidth: 0,
   },
@@ -244,7 +249,7 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
   footerText: {
-    color: '#666',
+    color: isDark ? Colors.dark.icon : '#666',
     fontSize: 16,
   },
   linkText: {
@@ -255,7 +260,7 @@ const styles = StyleSheet.create({
   demoInfo: {
     marginTop: 30,
     padding: 15,
-    backgroundColor: '#e3f2fd',
+    backgroundColor: isDark ? '#2a2d3a' : '#e3f2fd',
     borderRadius: 8,
     borderLeftWidth: 4,
     borderLeftColor: '#0066FF',
@@ -268,6 +273,6 @@ const styles = StyleSheet.create({
   },
   demoText: {
     fontSize: 12,
-    color: '#666',
+    color: isDark ? Colors.dark.icon : '#666',
   },
-}); 
+});

--- a/novo projeto junho/components/AppThemeProvider.tsx
+++ b/novo projeto junho/components/AppThemeProvider.tsx
@@ -1,0 +1,17 @@
+import React, { useEffect } from 'react';
+import { Text, View } from 'react-native';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+export function AppThemeProvider({ children }: { children: React.ReactNode }) {
+  const { isDark } = useColorScheme();
+  useEffect(() => {
+    const theme = isDark ? Colors.dark : Colors.light;
+    (Text as any).defaultProps = {
+      ...((Text as any).defaultProps || {}),
+      style: [{ color: theme.text }, ((Text as any).defaultProps && (Text as any).defaultProps.style) || {}],
+    };
+  }, [isDark]);
+
+  return <View style={{ flex: 1, backgroundColor: isDark ? Colors.dark.background : Colors.light.background }}>{children}</View>;
+}


### PR DESCRIPTION
## Summary
- add AppThemeProvider wrapper for default colors
- update layout to wrap application with provider
- adapt Login, Cadastro, Configuracoes and index screens to system theme

## Testing
- `npm run type-check` *(fails: numerous existing type errors)*
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: .eslintrc.js syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_684a4b91998c8325b1b68d6c57f8d8cb