### PR TITLE
Fix context logic and add missing functions

### DIFF
--- a/novo projeto junho/app/_layout.tsx
+++ b/novo projeto junho/app/_layout.tsx
@@ -7,7 +7,6 @@ import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { AuthProvider, useAuth } from '../contexts/AuthContext';
 import { NotificationProvider } from '../contexts/NotificationContext';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { useColorScheme } from '@/hooks/useColorScheme';

--- a/novo projeto junho/components/AddPlayerModal.tsx
+++ b/novo projeto junho/components/AddPlayerModal.tsx
@@ -19,9 +19,6 @@ interface Player {
   sport: string;
   position: string;
   teamId: string;
-  goals: number;
-  assists: number;
-  age: number;
   createdAt: string;
   updatedAt: string;
   stats: {
@@ -78,7 +75,7 @@ export function AddPlayerModal({ visible, onClose, editingPlayer }: AddPlayerMod
       setSport(editingPlayer.sport as keyof typeof sportsPositions);
       setPosition(editingPlayer.position);
       setTeamId(editingPlayer.teamId);
-      setAge(editingPlayer.age.toString());
+      setAge(editingPlayer.profile.age.toString());
     } else {
       resetForm();
     }

--- a/novo projeto junho/contexts/NotificationContext.tsx
+++ b/novo projeto junho/contexts/NotificationContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useContext, useEffect, ReactNode } from
 import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Alert } from 'react-native';
 
 interface NotificationContextType {
   badges: {
@@ -12,6 +13,7 @@ interface NotificationContextType {
   notifyEvent: (title: string, body: string) => Promise<void>;
   notifyStats: (title: string, body: string) => Promise<void>;
   notifyGuidance: (title: string, body: string) => Promise<void>;
+  showNotification: (message: string, type?: 'success' | 'error' | 'info') => void;
   clearBadge: (type: 'events' | 'stats' | 'guidance') => void;
 }
 
@@ -59,6 +61,14 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     await saveBadges({ ...badges, guidance: true });
   };
 
+  const showNotification = (
+    message: string,
+    type: 'success' | 'error' | 'info' = 'success'
+  ) => {
+    const title = type === 'error' ? 'Erro' : 'Sucesso';
+    Alert.alert(title, message);
+  };
+
   const clearBadge = (type: 'events' | 'stats' | 'guidance') => {
     const updated = { ...badges, [type]: false };
     saveBadges(updated);
@@ -80,7 +90,9 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <NotificationContext.Provider value={{ badges, notifyEvent, notifyStats, notifyGuidance, clearBadge }}>
+    <NotificationContext.Provider
+      value={{ badges, notifyEvent, notifyStats, notifyGuidance, showNotification, clearBadge }}
+    >
       {children}
     </NotificationContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add `showNotification` helper in NotificationContext
- implement guidance and player stats helpers in data context
- remove unused imports
- fix player modal age handling

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68522fbacec48325877ca73ea91a402f