### PR TITLE
Implement event editing and export

### DIFF
--- a/novo projeto junho/app/(tabs)/calendario.tsx
+++ b/novo projeto junho/app/(tabs)/calendario.tsx
@@ -9,24 +9,14 @@ import {
   Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { useAppData } from '../../contexts/AppDataContext';
+import { useAppData, Event } from '../../contexts/AppDataContext';
 import { AddEventModal } from '../../components/AddEventModal';
 
-interface Event {
-  id: string;
-  title: string;
-  type: 'jogo' | 'treino' | 'reuniao';
-  sport: string;
-  date: string;
-  time: string;
-  description: string;
-  location?: string;
-  createdAt: string;
-}
 
 export default function Calendario() {
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
   const [showEventModal, setShowEventModal] = useState(false);
+  const [editingEvent, setEditingEvent] = useState<Event | null>(null);
   const [selectedSport, setSelectedSport] = useState('Todos');
   const [selectedEventType, setSelectedEventType] = useState('Todos');
   const { events, getEventsBySport } = useAppData();
@@ -110,6 +100,7 @@ export default function Calendario() {
   };
 
   const handleAddEvent = () => {
+    setEditingEvent(null);
     setShowEventModal(true);
   };
 
@@ -120,7 +111,10 @@ export default function Calendario() {
       `Esporte: ${sportLabel}\nTipo: ${getEventTypeLabel(event.type)}\nData: ${new Date(event.date).toLocaleDateString('pt-BR')}\nHorário: ${event.time}\nLocal: ${event.location || 'Não informado'}\n\n${event.description || ''}`,
       [
         { text: 'Fechar', style: 'cancel' },
-        { text: 'Editar', onPress: () => Alert.alert('Editar', 'Funcionalidade em desenvolvimento') }
+        { text: 'Editar', onPress: () => {
+            setEditingEvent(event);
+            setShowEventModal(true);
+          } }
       ]
     );
   };
@@ -510,10 +504,14 @@ export default function Calendario() {
         )}
       </ScrollView>
 
-      <AddEventModal 
-        visible={showEventModal} 
-        onClose={() => setShowEventModal(false)}
+      <AddEventModal
+        visible={showEventModal}
+        onClose={() => {
+          setShowEventModal(false);
+          setEditingEvent(null);
+        }}
         selectedDate={selectedDate}
+        event={editingEvent || undefined}
       />
     </SafeAreaView>
   );

--- a/novo projeto junho/app/relatorios.tsx
+++ b/novo projeto junho/app/relatorios.tsx
@@ -11,6 +11,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useAppData } from '../contexts/AppDataContext';
+import { createBackupZip } from '../utils/backup';
 
 export default function Relatorios() {
   const router = useRouter();
@@ -49,12 +50,13 @@ export default function Relatorios() {
     return acc;
   }, {} as Record<string, number>);
 
-  const handleExport = () => {
-    Alert.alert(
-      'Exportar Relatório',
-      'Funcionalidade de exportação em desenvolvimento. Em breve você poderá exportar os relatórios em PDF.',
-      [{ text: 'OK' }]
-    );
+  const handleExport = async () => {
+    try {
+      const path = await createBackupZip();
+      Alert.alert('Sucesso!', `Relatório exportado para: ${path}`);
+    } catch (e) {
+      Alert.alert('Erro', 'Não foi possível exportar o relatório.');
+    }
   };
 
   const getTeamName = (teamId: string) => {

--- a/novo projeto junho/contexts/AppDataContext.tsx
+++ b/novo projeto junho/contexts/AppDataContext.tsx
@@ -39,7 +39,7 @@ interface Player {
   };
 }
 
-interface Event {
+export interface Event {
   id: string;
   title: string;
   type: 'jogo' | 'treino' | 'reuniao';
@@ -66,6 +66,7 @@ interface AppDataContextType {
   addTeam: (team: Omit<Team, 'id' | 'createdAt'>) => Promise<void>;
   addPlayer: (player: Omit<Player, 'id'>) => Promise<void>;
   addEvent: (event: Omit<Event, 'id' | 'createdAt'>) => Promise<void>;
+  updateEvent: (id: string, event: Partial<Event>) => Promise<void>;
   addGuidance: (playerId: string, guidance: Omit<Guidance, 'id'>) => Promise<void>;
   addPlayerStats: (playerId: string, stats: Record<string, number>) => Promise<void>;
   updateTeam: (id: string, team: Partial<Team>) => void;
@@ -340,6 +341,18 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
     }
   }, [players, showNotification]);
 
+  const updateEvent = useCallback(async (id: string, event: Partial<Event>) => {
+    try {
+      const updatedEvents = events.map(e => e.id === id ? { ...e, ...event } : e);
+      setEvents(updatedEvents);
+      await AsyncStorage.setItem('@GestaoTimes:events', JSON.stringify(updatedEvents));
+      showNotification('Evento atualizado com sucesso!');
+    } catch (error) {
+      console.error('Erro ao atualizar evento:', error);
+      showNotification('Erro ao atualizar evento', 'error');
+    }
+  }, [events, showNotification]);
+
   // Funções de remoção
   const deleteTeam = useCallback(async (id: string) => {
     try {
@@ -415,6 +428,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
     addTeam,
     addPlayer,
     addEvent,
+    updateEvent,
     updateTeam,
     updatePlayer,
     deleteTeam,


### PR DESCRIPTION
## Summary
- enable editing events via AddEventModal
- hook calendar page to edit events
- allow exporting reports using backup utility
- add updateEvent in AppDataContext

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: cannot find module declarations)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523dfcc3a083259551498b079c5a65